### PR TITLE
Generated clone method does not compile when extending an abstract parent

### DIFF
--- a/cc-xjc-plugin/src/main/java/net/sourceforge/ccxjc/PluginImpl.java
+++ b/cc-xjc-plugin/src/main/java/net/sourceforge/ccxjc/PluginImpl.java
@@ -514,7 +514,7 @@ public final class PluginImpl extends Plugin
                 this.log( Level.WARNING, "couldNotAddStdCtor", clazz.implClass.binaryName() );
             }
 
-            if ( this.getCopyConstructor( clazz ) == null )
+            if ( this.getOrGenerateCopyConstructor( clazz ) == null )
             {
                 this.log( Level.WARNING, "couldNotAddCopyCtor", clazz.implClass.binaryName() );
             }
@@ -571,11 +571,16 @@ public final class PluginImpl extends Plugin
 
     private JMethod getCopyConstructor( final ClassOutline clazz )
     {
-        JMethod ctor = clazz.implClass.getConstructor( new JType[]
+        final JMethod ctor = clazz.implClass.getConstructor( new JType[]
             {
                 clazz.implClass
             } );
+        return ctor;
+    }
 
+    private JMethod getOrGenerateCopyConstructor( final ClassOutline clazz )
+    {
+        JMethod ctor = this.getCopyConstructor(clazz);
         if ( ctor == null )
         {
             ctor = this.generateCopyConstructor( clazz );
@@ -2473,8 +2478,14 @@ public final class PluginImpl extends Plugin
 
         final JBlock copyBlock = new JBlock( false, false );
         copyBlock.directStatement( "// " + getMessage( "title" ) );
-        final JVar clone = copyBlock.decl( JMod.FINAL, clazz.implClass, "clone",
-                                           JExpr.cast( clazz.implClass, JExpr._super().invoke( "clone" ) ) );
+
+        final JExpression jE;
+        if (!clazz.implClass.isAbstract() && clazz.implClass._extends().isAbstract() && getCopyConstructor(clazz) != null) {
+            jE = JExpr._new( clazz.implClass ).arg(JExpr._this());
+        } else {
+            jE = JExpr.cast( clazz.implClass, JExpr._super().invoke( "clone" ) );
+        }
+        final JVar clone = copyBlock.decl( JMod.FINAL, clazz.implClass, "clone", jE );
 
         for ( FieldOutline field : clazz.getDeclaredFields() )
         {

--- a/cc-xjc-plugin/src/main/java/net/sourceforge/ccxjc/PluginImpl.java
+++ b/cc-xjc-plugin/src/main/java/net/sourceforge/ccxjc/PluginImpl.java
@@ -2718,19 +2718,23 @@ public final class PluginImpl extends Plugin
     {
         final Collection<String> types = new LinkedList<String>();
         final BufferedReader reader = new BufferedReader( new FileReader( fileName ) );
-        String line;
-
-        while ( ( line = reader.readLine() ) != null )
-        {
-            if ( line.indexOf( '#' ) > -1 )
+        try {
+            String line;
+    
+            while ( ( line = reader.readLine() ) != null )
             {
-                continue;
+                if ( line.indexOf( '#' ) > -1 )
+                {
+                    continue;
+                }
+    
+                if ( line.trim().length() > 0 )
+                {
+                    types.add( line.trim() );
+                }
             }
-
-            if ( line.trim().length() > 0 )
-            {
-                types.add( line.trim() );
-            }
+        } finally {
+            reader.close();
         }
 
         return Collections.unmodifiableCollection( types );


### PR DESCRIPTION
Mainly a simple fix, to use the copy constructor of the current instance instead of calling super.clone() in the generated clone method when the parent class is abstract.
